### PR TITLE
Feature mushroomcard

### DIFF
--- a/backend/src/application.js
+++ b/backend/src/application.js
@@ -14,6 +14,7 @@ const blogs = require("./routes/blogs");
 const users = require("./routes/users");
 const mushrooms = require("./routes/mushrooms");
 const logout = require("./routes/logout");
+const icons = require("./routes/icons");
 
 function read(file) {
   return new Promise((resolve, reject) => {
@@ -42,6 +43,7 @@ module.exports = function application() {
   app.use("/api", mushrooms(db));
   app.use("/api", blogs(db));
   app.use("/api", logout(db));
+  app.use("/api", icons(db));
 
   // Reading SQL files for database schema creation and seeding
   Promise.all([

--- a/backend/src/routes/icons.js
+++ b/backend/src/routes/icons.js
@@ -1,0 +1,18 @@
+const router = require("express").Router();
+
+module.exports = (db) => {
+  router.get("/icons", (request, response) => {
+    db.query(
+      `
+      SELECT DISTINCT MUSHROOM.ICON
+      FROM USER_ACCOUNT
+      JOIN BLOG ON USER_ACCOUNT.ID = BLOG.USER_ID
+      JOIN MUSHROOM ON BLOG.MUSHROOM_ID = MUSHROOM.ID
+      WHERE USER_ACCOUNT.EMAIL = 'jdoe@test.com';
+    `
+    ).then(({ rows: icons }) => {
+      response.json(icons);
+    });
+  });
+  return router;
+};

--- a/frontend/src/components/Account.jsx
+++ b/frontend/src/components/Account.jsx
@@ -11,10 +11,9 @@ const Account = () => {
   const fullname = cookieObject.fullname;
   const email = cookieObject.email;
   const profilePhoto = cookieObject.profilePhoto;
-
   return (
-    <main>
-      <MushroomCard fullname={fullname} email={email} profilePhoto={profilePhoto}/>
+    <main style={{ display: 'flex', justifyContent: 'center', marginTop: '50px' }}>
+      <MushroomCard fullname={fullname} email={email} profilePhoto={profilePhoto} />
     </main>
   );
 };

--- a/frontend/src/components/MushroomCard.jsx
+++ b/frontend/src/components/MushroomCard.jsx
@@ -1,11 +1,63 @@
+import { useState, useEffect } from "react";
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import CardMedia from '@mui/material/CardMedia';
+import Typography from '@mui/material/Typography';
+import { CardActionArea } from '@mui/material';
 
 const MushroomCard = (props) => {
   const { fullname, profilePhoto, email } = props;
+  const [icons, setIcons] = useState([]);
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch(`http://localhost:8001/api/icons`);
+        const data = await response.json();
+        setIcons(data);
+      } catch (error) {
+        console.error('Error fetching icon data:', error);
+      }
+    };
+    fetchData();
+  }, []);
+
   return (
-    <article>
-      
-    </article>
+    <Card>
+    <CardActionArea>
+      <CardMedia
+            component="img"
+            height="140"
+            image={profilePhoto}
+            alt="profile photo"
+      />
+      <CardContent>
+        <Typography gutterBottom variant="h5" component="div">
+          {fullname}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          <ul>
+            {icons.map((icon) => (
+              <img
+              style={{ width: '22px' }}
+              src={`images/${icon.icon}`}
+              />
+            ))}
+          </ul>
+        </Typography>
+      </CardContent>
+    </CardActionArea>
+  </Card>
   );
 };
 
 export default MushroomCard;
+  // <article>
+  //     <ul>
+  //       {icons.map((icon) => (
+  //         <img
+  //          style={{ width: '22px' }}
+  //          src={`images/${icon.icon}`}
+  //         />
+  //       ))}
+  //     </ul>
+  //   </article>

--- a/frontend/src/components/MushroomListItem.jsx
+++ b/frontend/src/components/MushroomListItem.jsx
@@ -6,7 +6,7 @@ const MushroomListItem = (props) => {
   return (
     <section className="mushroom-list__item">
       <img
-        className="mushroom-list__image"
+        className="mushroom-list__image" 
         src={`images/${mushroom.image}`}
         alt={mushroom.name}
       />
@@ -14,6 +14,7 @@ const MushroomListItem = (props) => {
       <p>Info: {mushroom.info}</p>
       <p>Edible? {mushroom.edible ? "Yes" : "No"}</p>
       <img
+        style={{ width: '22px' }}
         className="mushroom-list__image"
         src={`images/${mushroom.icon}`}
       />


### PR DESCRIPTION
Got a **ROUGH ROUGH** version of the mushroom icon card up.
Made a route for /icons with a query:
When we post blog forms, no matter if we are signed in, rn it only posts under John Doe. Until we fix that, I made the query for /icons only target the email of John Doe instead of logged in user, so I can test the icons populating the card.
But right now I got the query in api/icons to look into a users blog posts, find the mushroom ids, and then populate this card with the icons associated with those ids.

Did some minor in line styling instead of css because of the style overhaul we're going to do anyway, will sep. into proper .css then.
