### PR TITLE
Feature: edit blogs

### DIFF
--- a/backend/src/routes/journal.js
+++ b/backend/src/routes/journal.js
@@ -11,10 +11,12 @@ module.exports = (db) => {
         BLOG.TITLE AS title,
         USER_ACCOUNT.FULLNAME AS username,
         BLOG.PUBLICATION_DATE AS date,
-        json_agg(json_build_object(
-          'mushroom_name', MUSHROOM.TITLE,
-          'mushroom_image', MUSHROOM.IMAGE_URL
-        )) AS mushrooms,
+        COALESCE(json_agg(
+            json_build_object(
+                'mushroom_name', COALESCE(MUSHROOM.TITLE, ''),
+                'mushroom_image', COALESCE(MUSHROOM.IMAGE_URL, '')
+            )
+        ), '[]'::json) AS mushrooms,
         BLOG.CONTENT AS content,
         BLOG.LATITUDE AS lat,
         BLOG.LONGITUDE AS long
@@ -31,6 +33,9 @@ module.exports = (db) => {
     [email]
     ).then(({ rows: blogs }) => {
       response.json(blogs);
+    }).catch(error => {
+      console.error('Error executing query:', error);
+      response.status(500).json({ error: 'Internal Server Error' });
     });
   });
   return router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import FieldJournal from "./components/FieldJournal";
 import LoginSignup from "./components/LoginSignup";
 import BlogDetails from "./components/BlogDetails";
 import SearchResults from "./components/SearchResults";
+import FieldDetails from "./components/FieldDetails";
 
 function App() {
   const { state, setSelectedRoute, setBlogUpdate } = useApplicationData();
@@ -40,7 +41,7 @@ function App() {
           setBlogUpdate={setBlogUpdate}
         />
       ) : selectedRoute === "BLOGDETAILS" ? (
-        <BlogDetails blog={blogSelected} comments={commentData} />
+        <BlogDetails blog={blogSelected} comments={commentData} mushrooms={mushroomData} setBlogUpdate={setBlogUpdate} setSelectedRoute={setSelectedRoute} />
       ) : selectedRoute === "MUSHROOMS" ? (
         <MushroomList mushrooms={mushroomData} />
       ) : selectedRoute === "FIELDJOURNAL" ? (
@@ -55,6 +56,8 @@ function App() {
           <Account users={userData}/>
       ) : selectedRoute === "LOGINSIGNUP" ? (
         <LoginSignup setSelectedRoute={setSelectedRoute} setValue = {setValue}/>
+      ) : selectedRoute === "FIELDDETAILS" ? (
+        <FieldDetails blog={blogSelected} comments={commentData} mushrooms={mushroomData} setBlogUpdate={setBlogUpdate} setSelectedRoute={setSelectedRoute} />
       ) : <SearchResults searchTerm={searchTerm}/>}
     </div>
   );

--- a/frontend/src/components/BlogEdit.jsx
+++ b/frontend/src/components/BlogEdit.jsx
@@ -1,0 +1,159 @@
+import React, { useState, useEffect } from "react";
+import BlogFormMap from "./BlogFormMap";
+import "../styles/BlogForm.scss";
+
+const BlogEdit = (props) => {
+  const { mushrooms, setBlogUpdate, existingBlog, setEditMode, setSelectedRoute } = props;
+  const [disableAddMushroom, setDisableAddMushroom] = useState(true);
+
+  const [formData, setFormData] = useState({
+    title: existingBlog.title || "",
+    content: existingBlog.content || "",
+    latitude: existingBlog.latitude || 1,
+    longitude: existingBlog.longitude || 1,
+    user_id: existingBlog.user_id || 1,
+    mushrooms: existingBlog.mushrooms || [{}],
+  });
+
+  useEffect(() => {
+    // Set initial form data when existingBlog changes
+    setFormData({
+      title: existingBlog.title || "",
+      content: existingBlog.content || "",
+      latitude: existingBlog.latitude || 1,
+      longitude: existingBlog.longitude || 1,
+      user_id: existingBlog.user_id || 1,
+      mushrooms: existingBlog.mushrooms || [{}],
+    });
+  }, [existingBlog]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((prevData) => ({
+      ...prevData,
+      [name]: value,
+    }));
+  };
+
+  const handleMushroomSelection = (event, index) => {
+    const selectedMushroomId = event.target.value;
+    setFormData((prevData) => {
+      const updatedMushrooms = [...prevData.mushrooms];
+      updatedMushrooms[index] = { mushroom_id: selectedMushroomId };
+      return {
+        ...prevData,
+        mushrooms: updatedMushrooms,
+      };
+    });
+    setDisableAddMushroom(false);
+  };
+
+  const handleAddMushroom = () => {
+    setFormData((prevData) => ({
+      ...prevData,
+      mushrooms: [...prevData.mushrooms, { mushroom_id: "" }],
+    }));
+    setDisableAddMushroom(true);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const mushroomIds = formData.mushrooms.map((mushroom) => mushroom.mushroom_id);
+    try {
+      // Put request to update the existing blog
+      const blogResponse = await fetch(`http://localhost:8001/api/blogs/${existingBlog.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: formData.title,
+          content: formData.content,
+          latitude: formData.latitude,
+          longitude: formData.longitude,
+          user_id: formData.user_id,
+          mushrooms: mushroomIds,
+        }),
+      });
+  
+      if (!blogResponse.ok) {
+        throw new Error(`Failed to update blog. Status: ${blogResponse.status}`);
+      }
+  
+      const updatedBlogData = await blogResponse.json();
+      console.log("Blog updated:", updatedBlogData);
+  
+      // Reset the form after submission
+      setFormData({
+        title: "",
+        content: "",
+        latitude: null,
+        longitude: null,
+        user_id: 1,
+        mushrooms: [],
+      });
+  
+      setBlogUpdate(true);
+      setEditMode(false); // Exit edit mode after submitting
+      setSelectedRoute("FIELDJOURNAL");
+    } catch (error) {
+      console.error("Error when updating:", error.message);
+    }
+  };
+
+  return (
+    <form className="blog-form">
+      <div className="form-content">
+        <section className="form-input">
+          <label>
+            <input
+              type="text"
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              placeholder="Enter Blog Title"
+            />
+          </label>
+  
+          <input
+            type="text"
+            name="content"
+            value={formData.content}
+            onChange={handleChange}
+            placeholder="Enter Blog Content"
+          />
+  
+          {formData.mushrooms.map((mushroom, index) => (
+            <div key={index}>
+              <select
+                name={`mushroom_id_${index}`}
+                value={mushroom.mushroom_id}
+                onChange={(event) => handleMushroomSelection(event, index)}
+              >
+                <option value="">Select Mushroom</option>
+                {mushrooms.map((mushroomOption) => (
+                  <option key={mushroomOption.id} value={mushroomOption.id}>
+                    {mushroomOption.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+          {formData.mushrooms.length < 4 && (
+            <button type="button" onClick={handleAddMushroom} disabled={disableAddMushroom}>
+              Add Mushroom
+            </button>
+          )}
+        </section>
+        <section className="map">
+          <BlogFormMap setFormData={setFormData} />
+        </section>
+      </div>
+      <button type="button" onClick={handleSubmit}>
+        Submit
+      </button>
+    </form>
+  );
+};
+
+export default BlogEdit;

--- a/frontend/src/components/FieldDetails.jsx
+++ b/frontend/src/components/FieldDetails.jsx
@@ -1,0 +1,125 @@
+import React, { useState } from "react";
+import BlogListMap from "./BlogListMap";
+import Comments from "./Comments";
+import BlogEdit from "./BlogEdit";
+
+const FieldDetails = (props) => {
+  const { blog, comments, mushrooms, setBlogUpdate, setSelectedRoute } = props;
+  const [newComment, setNewComment] = useState({
+    blog_Id: blog.id,
+    commenter_Id: 1,
+    message: "",
+  });
+  const [editMode, setEditMode] = useState(false);
+
+  const handleChange = (event) => {
+    const { name: input, value } = event.target;
+    setNewComment((prevData) => ({
+      ...prevData,
+      [input]: value,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (newComment.message.trim() === "") {
+      console.error("Comment message cannot be empty");
+      return;
+    }
+
+    try {
+      const response = await fetch("http://localhost:8001/api/comments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(newComment),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to post comment. Status: ${response.status}`);
+      }
+
+      const responseData = await response.json();
+      console.log("Comment posted:", responseData);
+
+      setNewComment({
+        blog_Id: blog.id,
+        commenter_Id: 1,
+        message: "",
+      });
+    } catch (error) {
+      console.error("Error when posting:", error.message);
+    }
+  };
+
+  const handleEditClick = () => {
+    setEditMode(true);
+  };
+
+  return (
+    <main>
+      {editMode ? (
+        <BlogEdit setEditMode={setEditMode} mushrooms={mushrooms} existingBlog={blog} setBlogUpdate={setBlogUpdate} setSelectedRoute={setSelectedRoute} />
+      ) : (
+        <section className="blog-container">
+          <div className="map">
+            <BlogListMap location={{ lat: blog.lat, lng: blog.long }} />
+          </div>
+          <header className="blog-header">
+            <div className="blog-info">
+              <h1>{blog.title}</h1>
+              <div>By: {blog.username}</div>
+            </div>
+
+            {blog.mushrooms.map((mushroom, index) => (
+              <div key={index} className="mushrooms-info">
+                {mushroom.mushroom_name}
+                <img
+                  className="mushroom-image"
+                  src={`images/${mushroom.mushroom_image}`}
+                  alt={mushroom.mushroom_name}
+                />
+              </div>
+            ))}
+          </header>
+          <section>
+            <p>{blog.content}</p>
+          </section>
+          <section className="comments-container">
+            <form>
+              <label>
+                <input
+                  type="text"
+                  name="message"
+                  value={newComment.message}
+                  onChange={handleChange}
+                  placeholder="Enter Comment"
+                />
+              </label>
+              <button type="button" onClick={handleSubmit}>
+                Submit
+              </button>
+            </form>
+            <div>
+              {comments
+                .filter((comment) => comment.blog_id === blog.id)
+                .map((comment) => (
+                  <div key={comment.id}>
+                    <Comments comment={comment} />
+                  </div>
+                ))}
+            </div>
+            <footer>
+              <button type="button" onClick={handleEditClick}>
+                Edit
+              </button>
+            </footer>
+          </section>
+        </section>
+      )}
+    </main>
+  );
+};
+
+export default FieldDetails;

--- a/frontend/src/components/FieldJournalItem.jsx
+++ b/frontend/src/components/FieldJournalItem.jsx
@@ -5,7 +5,7 @@ const FieldJournalItem = (props) => {
 
   const handleClick = () => {
     setBlogSelected(blog);
-    setSelectedRoute("BLOGDETAILS");
+    setSelectedRoute("FIELDDETAILS");
   };
 
   return (
@@ -15,17 +15,25 @@ const FieldJournalItem = (props) => {
       </div>
       <div>{blog.title}</div>
       <div>By: {blog.username}</div>
-      <img
-        className="mushroom-list__image"
-        src={`images/${blog.mushroom_image}`}
-        alt={blog.mushroom}
-      />
-      <div className="mushroom-list__details">
-        <footer className="mushroom-list__info">
-          <div>{blog.mushroom}</div>
-          <div className="mushroom-list__description">{blog.content}</div>
-        </footer>
-      </div>
+      {blog.mushrooms && blog.mushrooms.length > 0 && (
+        <div>
+          {blog.mushrooms.map((mushroom, index) => (
+            <div key={index}>
+              <img
+                className="mushroom-list__image"
+                src={`images/${mushroom.mushroom_image}`}
+                alt={mushroom.mushroom_name}
+              />
+              <div>{mushroom.mushroom_name}</div>
+            </div>
+          ))}
+          <div className="mushroom-list__details">
+            <footer className="mushroom-list__info">
+              <div className="mushroom-list__description">{blog.content}</div>
+            </footer>
+          </div>
+        </div>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
Updated /journal + FieldJournalItem to reflect new joining table. Should be no crashes in the backend anymore.

**New components: FieldDetails, BlogEdit**
FieldDetails is just like BlogDetails, but only available through the field journals, so users can only edit their own blogs.
It brings up their blog details, and gives you an edit button to click. 
Once button is clicked it brings you to BlogEdit which is like BlogForm, only it UPDATES instead of INSERTS. 

**New Route: /blogs/:id**
This route updates the blogs, deletes the mushroom_post mushrooms, then inserts the new ones.

Updated App.jsx to pass things down, and to establish FIELDDETAILS as a selectedRoute.